### PR TITLE
Fixed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # maths-things
 Full of maths things
 
-Go to [Here](https://n-yelland.github.io/maths-things/nic_mathma)
+Go to [Here](https://nicyelland.com/nic_mathma)


### PR DESCRIPTION
Link previously pointed to personal n-yelland.github.io/maths-things URL, which then in turn redirects back to the nicyelland.com domain. I've cut out the middle man by changing the link so it goes straight to the nicyelland.com domain.