### PR TITLE
Fix quaternions.md markdown processing issues

### DIFF
--- a/quaternions.md
+++ b/quaternions.md
@@ -66,4 +66,4 @@ class Qtrn:
         q2 = self._c
         #invert q2 and then return q1 * inverse(q2)
         #incomplete!
-       ```
+```


### PR DESCRIPTION
~ Github's automatic markdown renderer appears to render this incorrectly on GitHub Pages (although not, notably, on GitHub itself) - instead of noting the ` ```python` and then creating a ` <pre> ` element for everything inside it, it instead decides that the `#` -> ` <h1> ` process is more important, and incorrectly processes this rule first, despite the fact that `#` is used for comments in python. This happens if the closing ` ``` ` tag is missing or misaligned at the end of the code, as it was here.

Edit: it appears markdown styling is also a thing in comments - whoops! Added in the required code tags so that the comment displays properly (argh... this is the ampersand problem all over again!)